### PR TITLE
retrieve message

### DIFF
--- a/knock_integration_log_client/__init__.py
+++ b/knock_integration_log_client/__init__.py
@@ -207,7 +207,7 @@ class IntegrationLoggingService(object):
         stacktrace = traceback.format_exc()
 
         return dict(
-            message=exception.message,
+            message=exception.args[0],
             stack_trace=stacktrace,
             created_time=arrow.now().isoformat()
         )


### PR DESCRIPTION
exception.message attribute deprecated in python 3 
so we need to retrieve message from agrs